### PR TITLE
Fix bug causing crash on WSL and obscure systems with no locale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 CXX = c++
 
 # Optimization:
-CXXFLAGS += -O3
+#CXXFLAGS += -O3
+CXXFLAGS += -g
 
 # Warnings:
 CXXFLAGS += -Wall

--- a/src/engine/PUtils.cpp
+++ b/src/engine/PUtils.cpp
@@ -129,13 +129,20 @@ void GetLanguage(char* lang) {
 		#warning SDL version must be at least 2.0.14 to support locale
 		const char* locale = "en";
 	#else
-		const char* locale = SDL_GetPreferredLocales()->language;
+		// Abdullah: should've considered that SDL_GetPrefferedLocales() returns NULL on error (such as if a system doesn't have a locale, like WSL)
+		char locale[5] = "en";
+		SDL_Locale* locales = SDL_GetPreferredLocales();
+		if (locales)
+		{
+			locale[0] = locales[0].language[0]; // there should be a better way to do this but meh,
+			locale[1] = locales[0].language[1]; 
+			// heh there was a memory leak here interesting, good thing this function is called only once
+		}
+		SDL_free(locales); 
 	#endif
-
 	lang[0] = SDL_tolower(locale[0]);
-	lang[1] = SDL_tolower(locale[1]); 
+	lang[1] = SDL_tolower(locale[1]);     // there should be a better way to do this but meh,
 	lang[2] = '\0';
-
 }
 
 void Show_Error(const char* txt) {


### PR DESCRIPTION
Also there was a memory leak since `SDL_free()` wasn't called on the return value of `SDL_GetPreferredLocale()`


Feel free to disregard the makefile changes, but please add some kind of make flag that allows compiling by `-g` like `make -j4 -DEBUG pk2` or something
 
Thanks