### PR TITLE
Made PLog::Write() more generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ CXX = c++
 
 # Optimization:  run "make -j4 pk2 DEBUG=1" to enable debug symbols or else compile normally
 ifdef DEBUG
-$(info --Debugging symbols enabled) 
-CXXFLAGS += -g
+$(info ->Debugging symbols enabled) 
+	CXXFLAGS += -g
 else
-$(info --Release mode)
-CXXFLAGS += -O3
+$(info ->Release mode)
+	CXXFLAGS += -O3
 endif
 
 #CXXFLAGS += -g
@@ -48,14 +48,12 @@ CXXFLAGS += -DCOMMIT_HASH='"$(shell git rev-parse --short HEAD)"'
 
 
 UNAME_S = $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-# Support MAC OS
-#@echo ->Compiling for Mac OS
+ifeq ($(UNAME_S),Darwin)                            # Support MAC OS
+$(info ->Compiling for Mac OS)
 	CXXFLAGS += -I/opt/homebrew/include
 	COMPILE_COMMAND = $(CXX) $(CXXFLAGS)
-else
-# Support Linux
-#@echo ->Compiling for Windows MSYS2/Linux
+else                                                # Support Linux
+$(info ->Compiling for Windows MSYS2/Linux) 
 	COMPILE_COMMAND = $(CXX)
 # Uncomment this to support OpenGL rendering
 #	CXXFLAGS += -DPK2_USE_GL
@@ -112,7 +110,7 @@ all: pk2
 clean:
 	@rm -rf $(BIN_DIR)
 	@rm -rf $(BUILD_DIR)
-	@echo -Cleaned
+	@echo \#\#\#\# Cleaned \#\#\#\#
 
 version_test:
 	echo $(PK2_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,8 @@
 # Compiler:
 CXX = c++
 
-# Optimization:  run "make -j4 pk2 DEBUG=1" to enable debug symbols or else compile normally
-ifdef DEBUG
-$(info ->Debugging symbols enabled) 
-	CXXFLAGS += -g
-else
-$(info ->Release mode)
-	CXXFLAGS += -O3
-endif
-
+# Optimization:
+CXXFLAGS += -O3
 #CXXFLAGS += -g
 
 # Warnings:
@@ -40,7 +33,7 @@ ifeq ($(PK2_VERSION),)
 endif
 
 
-# Portable (data is stored with resources):
+# Portable (data is stored with resorces):
 CXXFLAGS += -DPK2_PORTABLE -DPK2_VERSION=\"$(PK2_VERSION)\"
 
 # Commit hash
@@ -48,12 +41,11 @@ CXXFLAGS += -DCOMMIT_HASH='"$(shell git rev-parse --short HEAD)"'
 
 
 UNAME_S = $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)                            # Support MAC OS
-$(info ->Compiling for Mac OS)
+ifeq ($(UNAME_S),Darwin)
+# Support MAC OS
 	CXXFLAGS += -I/opt/homebrew/include
 	COMPILE_COMMAND = $(CXX) $(CXXFLAGS)
-else                                                # Support Linux
-$(info ->Compiling for Windows MSYS2/Linux) 
+else
 	COMPILE_COMMAND = $(CXX)
 # Uncomment this to support OpenGL rendering
 #	CXXFLAGS += -DPK2_USE_GL
@@ -110,7 +102,6 @@ all: pk2
 clean:
 	@rm -rf $(BIN_DIR)
 	@rm -rf $(BUILD_DIR)
-	@echo \#\#\#\# Cleaned \#\#\#\#
 
 version_test:
 	echo $(PK2_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,15 @@
 # Compiler:
 CXX = c++
 
-# Optimization:
+# Optimization:  run "make -j4 pk2 DEBUG=1" to enable debug symbols or else compile normally
+ifdef DEBUG
+$(info --Debugging symbols enabled) 
+CXXFLAGS += -g
+else
+$(info --Release mode)
 CXXFLAGS += -O3
+endif
+
 #CXXFLAGS += -g
 
 # Warnings:
@@ -33,7 +40,7 @@ ifeq ($(PK2_VERSION),)
 endif
 
 
-# Portable (data is stored with resorces):
+# Portable (data is stored with resources):
 CXXFLAGS += -DPK2_PORTABLE -DPK2_VERSION=\"$(PK2_VERSION)\"
 
 # Commit hash
@@ -43,9 +50,12 @@ CXXFLAGS += -DCOMMIT_HASH='"$(shell git rev-parse --short HEAD)"'
 UNAME_S = $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 # Support MAC OS
+#@echo ->Compiling for Mac OS
 	CXXFLAGS += -I/opt/homebrew/include
 	COMPILE_COMMAND = $(CXX) $(CXXFLAGS)
 else
+# Support Linux
+#@echo ->Compiling for Windows MSYS2/Linux
 	COMPILE_COMMAND = $(CXX)
 # Uncomment this to support OpenGL rendering
 #	CXXFLAGS += -DPK2_USE_GL
@@ -102,6 +112,7 @@ all: pk2
 clean:
 	@rm -rf $(BIN_DIR)
 	@rm -rf $(BUILD_DIR)
+	@echo -Cleaned
 
 version_test:
 	echo $(PK2_VERSION)

--- a/src/engine/PLog.hpp
+++ b/src/engine/PLog.hpp
@@ -22,8 +22,10 @@ enum {
 };
 
 void Init(u8 level, PFile::Path file);
-void Write(const char* txt);
-void Write(u8 level, const char* origin, const char* format, ...);
+void Write(const char* format, ...);                                    // generic logger for use by developers, with default level of 'DEBUG' and origin "PLog"
+void Write(u8 level, const char* format, ...);                           // custom level, default origin "PLog"
+void Write(const char* origin, const char* format, ...);                 // custom origin, default level 'DEBUG'
+void Write(u8 level, const char* origin, const char* format, ...);      // fully customizable logger
 void Exit();
 
 }


### PR DESCRIPTION
Should work right off the bat, ensured backwards compatibility with all existing calls to PLog::Write(), don't worry.