### PR TITLE
Removing dependencies of some unneeded functions

### DIFF
--- a/src/game/physics.cpp
+++ b/src/game/physics.cpp
@@ -725,7 +725,9 @@ void UpdateSprite(SpriteClass* sprite){
 
 		sprite->super_mode_timer--;
 		if (Player_Sprite->super_mode_timer == 0)
-			PSound::resume_music();
+			//PSound::resume_music();
+			PSound::start_music(PFile::Path("music" PE_SEP "song01.xm"));   // the problem is we dont have the music that was playing previously, fixlater
+			
 	
 	}
 
@@ -1588,7 +1590,8 @@ void UpdateBonusSprite(SpriteClass* sprite){
 
 			if (sprite->HasAI(AI_BONUS_SUPERMODE)) {
 				Player_Sprite->super_mode_timer = sprite->prototype->charge_time;
-				PSound::play_overlay_music();
+				//PSound::play_overlay_music();
+				PSound::start_music(PFile::Path("music" PE_SEP "super.xm"));   // the problem is this will most likely overwrite the current music, fixlater
 			}
 
 			//Game->map.spritet[(int)(sprite->orig_x/32) + (int)(sprite->orig_y/32)*PK2MAP_MAP_WIDTH] = 255;

--- a/src/screens/playing_screen.cpp
+++ b/src/screens/playing_screen.cpp
@@ -884,7 +884,8 @@ void PlayingScreen::Loop(){
 		} if (PInput::Keydown(PInput::V))
 			Player_Sprite->invisible_timer = 3000;
 		if (PInput::Keydown(PInput::S)) {
-			PSound::play_overlay_music();
+			//PSound::play_overlay_music();   // this does the exact same thing as start_music()
+			PSound::start_music(PFile::Path("music" PE_SEP "super.xm"));   // the problem is this will most likely overwrite the current music, fixlater
 			Player_Sprite->super_mode_timer = 490;
 			key_delay = 30;
 		}

--- a/src/screens/screens_handler.cpp
+++ b/src/screens/screens_handler.cpp
@@ -125,7 +125,8 @@ ScreensHandler::ScreensHandler():
 	PDraw::image_load(game_assets, PFile::Path("gfx" PE_SEP "pk2stuff.bmp"), false);
 	PDraw::image_load(game_assets2, PFile::Path("gfx" PE_SEP "pk2stuff2.bmp"), false);
 
-	PSound::load_overlay_music(PFile::Path("music" PE_SEP "super.xm"));
+	//PSound::load_overlay_music(PFile::Path("music" PE_SEP "super.xm"));  // why? what is so special about this one xm that it needs to be loaded at runtime?
+	// I propose that we resort to start_music() for powerups that require special effects.	
 
 	sfx_global.loadAll();
 	//Load_SFX();


### PR DESCRIPTION
PK2_SDL implements a feature that plays a different music on top of the currently playing level music depending on game events, like when a player transforms into 'Super Mode'. Before this, PK2 never needed or had a feature that required the currently playing music to change. To achieve this, 3 functions are used.

    PSound::resume_music();
    PSound::play_overlay_music();
    PSound::load_overlay_music();

But in practice these perform the same function(and behave in the exact same way) as `PSound::start_music()`, so I'm replacing all occurences of these calls with `start_music()` for now.

**Since the previously playing music is overwritten when Super Mode starts, keep in mind that I've temporarily set `song01.xm` to play when Super Mode ends.** 

I'll figure out a way to keep the previous music, and generalize this and have a list of music instead, but that's for later.