### PR TITLE
Add 'Show FPS' to Graphics Settings.

### DIFF
--- a/res/language/deutsch.txt
+++ b/res/language/deutsch.txt
@@ -115,6 +115,9 @@ Graphics
 *graphics menu fullscreen on:           Vollbild an
 *graphics menu fullscreen off:          Vollbild aus
 
+*graphics menu showfps on:              fps sichtbar
+*graphics menu showfps off:             fps nicht sichtbar
+
 *graphics menu touchscreen on:          Touchscreen Modus an
 *graphics menu touchscreen off:         Touchscreen Modus aus
 

--- a/res/language/english.txt
+++ b/res/language/english.txt
@@ -112,6 +112,9 @@ Graphics
 *graphics menu fullscreen on:           fullscreen on
 *graphics menu fullscreen off:          fullscreen off
 
+*graphics menu showfps on:              fps is visible
+*graphics menu showfps off:             fps is not visible
+
 *graphics menu touchscreen on:          touchscreen mode on
 *graphics menu touchscreen off:         touchscreen mode off
 

--- a/res/language/italiano.txt
+++ b/res/language/italiano.txt
@@ -64,6 +64,8 @@ Graphics
 *main menu back:                          indietro
 *graphics menu fullscreen on:             fullscreen attivo
 *graphics menu fullscreen off:            fullscreen inattivo
+*graphics menu showfps on:                fps visibile
+*graphics menu showfps off:               fps invisibile
 *graphics menu game speed:                velocitå
 *graphics menu texture filtering:         filtro
 

--- a/res/language/polski.txt
+++ b/res/language/polski.txt
@@ -101,6 +101,9 @@ Graphics
 *graphics menu fullscreen on:		pełny ekran wł
 *graphics menu fullscreen off:		pełny ekran wył
 
+*graphics menu showfps on:              fps widoczne
+*graphics menu showfps off:             fps niewidoczne
+
 *graphics menu touchscreen on:		tryb ekranu dotykowego wł
 *graphics menu touchscreen off:		tryb ekranu dotykowego wył
 

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -193,6 +193,9 @@ void Load_Language(const std::string& language) {
 	PK_txt.gfx_fullscreen_on  	    = tekstit->searchLocalizedText("graphics menu fullscreen on");
 	PK_txt.gfx_fullscreen_off       = tekstit->searchLocalizedText("graphics menu fullscreen off");
 
+	PK_txt.gfx_showfps_on  	    	= tekstit->searchLocalizedText("graphics menu showfps on");
+	PK_txt.gfx_showfps_off       	= tekstit->searchLocalizedText("graphics menu showfps off");
+
 	PK_txt.gfx_touchscreen_on       = tekstit->searchLocalizedText("graphics menu touchscreen on");
 	PK_txt.gfx_touchscreen_off      = tekstit->searchLocalizedText("graphics menu touchscreen off");
 

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -101,6 +101,9 @@ public:
 		gfx_fullscreen_on = -1,
 		gfx_fullscreen_off = -1,
 
+		gfx_showfps_on = -1,
+		gfx_showfps_off = -1,
+
 		gfx_game_speed = -1,
 		gfx_texture_filtering  = -1,
 

--- a/src/screens/menu_screen.cpp
+++ b/src/screens/menu_screen.cpp
@@ -588,11 +588,11 @@ void MenuScreen::Draw_Menu_Graphics() {
 			Settings.show_fps = !Settings.show_fps;	
 		}
 		if (Settings.show_fps){
-			if (Draw_Menu_Text("fps is visible",180,my)){
+			if (Draw_Menu_Text(tekstit->Get_Text(PK_txt.gfx_showfps_on),180, my)){
 				Settings.show_fps = false;
 			}
 		} else{
-			if (Draw_Menu_Text("fps is not visible",180,my)){
+			if (Draw_Menu_Text(tekstit->Get_Text(PK_txt.gfx_showfps_off),180,my)){
 				Settings.show_fps = true;
 			}
 		}

--- a/src/screens/menu_screen.cpp
+++ b/src/screens/menu_screen.cpp
@@ -564,8 +564,9 @@ void MenuScreen::Draw_Menu_Graphics() {
 
 	PDraw::font_write_line(fontti2,tekstit->Get_Text(PK_txt.gfx_title),50,90);
 
-	if(moreOptions){
+	if(moreOptions){  // settings: graphics: 2nd page
 		bool wasFullScreen = Settings.isFullScreen;
+		bool wasShowingFPS = Settings.show_fps;
 		int  oldfps = Settings.fps;
 
 		if (Settings.isFullScreen){
@@ -579,6 +580,21 @@ void MenuScreen::Draw_Menu_Graphics() {
 		}
 		if (PK2gui::Draw_BoolBox(100, my, Settings.isFullScreen, true)) {
 			Settings.isFullScreen = !Settings.isFullScreen;
+		}
+		my += 40;
+
+
+		if (PK2gui::Draw_BoolBox(100, my, Settings.show_fps, true)) {
+			Settings.show_fps = !Settings.show_fps;	
+		}
+		if (Settings.show_fps){
+			if (Draw_Menu_Text("fps is visible",180,my)){
+				Settings.show_fps = false;
+			}
+		} else{
+			if (Draw_Menu_Text("fps is not visible",180,my)){
+				Settings.show_fps = true;
+			}
 		}
 		my += 40;
 
@@ -645,6 +661,10 @@ void MenuScreen::Draw_Menu_Graphics() {
 			save_settings = true;
 			PRender::set_fullscreen(Settings.isFullScreen);
 		}
+		if(wasShowingFPS != Settings.show_fps) { // 
+			save_settings = true;
+			show_fps = Settings.show_fps;
+		}
 
 		if (Settings.fps != oldfps) {
 			int ret = -1;
@@ -673,7 +693,7 @@ void MenuScreen::Draw_Menu_Graphics() {
 		}
 
 	}
-	else {
+	else {               // settings: graphics: 1st page
 		this->my = 150;
 
 		this->drawBoolBoxGroup(Settings.transparent_text,

--- a/src/screens/playing_screen.cpp
+++ b/src/screens/playing_screen.cpp
@@ -415,6 +415,8 @@ void PlayingScreen::Init(){
 	
 	PDraw::set_offset(screen_width, screen_height);
 
+	show_fps = Settings.show_fps;  // in game menu setting currently overrides --fps commandline argument 
+
 	if (!Game->isStarted()) {
 
 		Game->start();

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -52,6 +52,7 @@ void Settings_Init() {
 #endif
 
 	Settings.fps = SETTINGS_60FPS;//SETTINGS_VSYNC;
+	Settings.show_fps = false; 
 	Settings.isFullScreen = true;
 	Settings.double_speed = false;
 	Settings.shader_type = SETTINGS_MODE_LINEAR;
@@ -120,6 +121,7 @@ void from_json(const nlohmann::json& j, PK2SETTINGS& s){
 	j.at("gui").get_to(s.draw_gui);
 	j.at("touchscreen").get_to(s.touchscreen_mode);
 	j.at("fps").get_to(s.fps);
+	j.at("show_fps").get_to(s.show_fps);
 	j.at("fullscreen").get_to(s.isFullScreen);
 	j.at("double_speed").get_to(s.double_speed);
 
@@ -141,6 +143,7 @@ void from_json(const nlohmann::json& j, PK2SETTINGS& s){
 void to_json(nlohmann::json& j, const PK2SETTINGS& s){
 	j["language"] = s.language;
 	j["gui"] = s.draw_gui;
+	j["show_fps"] = s.show_fps;
 
 	j["touchscreen"] = s.touchscreen_mode;
 	j["fps"] = s.fps;

--- a/src/settings/settings.hpp
+++ b/src/settings/settings.hpp
@@ -61,7 +61,7 @@ public:
 	bool  draw_gui = false;
 	bool  touchscreen_mode = false;
 	
-	int   fps;
+	int   fps;  // desired fps target (default 60)
 	bool  isFullScreen = true;
 	bool  double_speed = false;
 	u8    shader_type;
@@ -78,6 +78,7 @@ public:
 
 	// GUI
 	//bool gui;
+	bool show_fps;
 
 	friend void from_json(const nlohmann::json& j, PK2SETTINGS& settings);
 	friend void to_json(nlohmann::json& j, const PK2SETTINGS& settings); 


### PR DESCRIPTION
Feel free to make changes if necessary. Tested on linux, but there shouldn't be much of a significant change. 

PS: this makes the show_fps argument to pk2_main() redundant, so in a future revision it should be removable from the function call.