### PR TITLE
Fix build errors with Lua 5.5

### DIFF
--- a/src/3rd_party/sol.hpp
+++ b/src/3rd_party/sol.hpp
@@ -20,9 +20,14 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file was generated with a script.
-// Generated 2026-01-05 22:11:40.196160 UTC
-// This header was generated with sol v3.5.0 (revision c1f95a77)
+// Generated 2026-04-07 14:08:57.524621 UTC
+// This header was generated with sol v3.0.2 (revision 16a9fabb)
 // https://github.com/ThePhD/sol2
+
+// Using sol2 from PR #1723 for Lua 5.5 compatibility
+// TODO: switch to release when merged
+// https://github.com/ThePhD/sol2/pull/1723
+
 
 #ifndef SOL_SINGLE_INCLUDE_SOL_HPP
 #define SOL_SINGLE_INCLUDE_SOL_HPP
@@ -3632,11 +3637,11 @@ COMPAT53_API void luaL_requiref(lua_State *L, const char *modname,
 #endif /* Lua 5.2 only */
 
 /* other Lua versions */
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
 
-#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
+#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, 5.4, or 5.5)"
 
-#endif /* other Lua versions except 5.1, 5.2, 5.3, and 5.4 */
+#endif /* other Lua versions except 5.1, 5.2, 5.3, 5.4, and 5.5 */
 
 /* helper macro for defining continuation functions (for every version
 * *except* Lua 5.2) */
@@ -4522,16 +4527,16 @@ extern "C" {
 }
 #endif
 
-#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 504
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 504
 
 #if !defined(LUA_ERRGCMM)
-/* So Lua 5.4 actually removes this, which breaks sol2...
+/* So Lua 5.4 or later actually removes this, which breaks sol2...
  man, this API is quite unstable...!
 */
 #  define LUA_ERRGCMM (LUA_ERRERR + 2)
 #endif /* LUA_ERRGCMM define */
 
-#endif // Lua 5.4 only
+#endif // Lua 5.4 or later
 
 #endif // NOT_KEPLER_PROJECT_COMPAT54_H_// end of sol/compatibility/compat-5.4.h
 
@@ -28584,6 +28589,14 @@ namespace sol {
 
 // end of sol/thread.hpp
 
+inline lua_State* sol_lua_newstate(lua_Alloc f, void* ud, [[maybe_unused]] unsigned seed = 0) {
+#if LUA_VERSION_NUM >= 505
+	return ::lua_newstate(f, ud, seed);
+#else
+	return ::lua_newstate(f, ud);
+#endif
+}
+
 namespace sol {
 
 	class state : private std::unique_ptr<lua_State, detail::state_deleter>, public state_view {
@@ -28596,7 +28609,7 @@ namespace sol {
 		}
 
 		state(lua_CFunction panic, lua_Alloc alfunc, void* alpointer = nullptr)
-		: unique_base(lua_newstate(alfunc, alpointer)), state_view(unique_base::get()) {
+		: unique_base(sol_lua_newstate(alfunc, alpointer)), state_view(unique_base::get()) {
 			set_default_state(unique_base::get(), panic);
 		}
 


### PR DESCRIPTION
Fixes build errors with Lua 5.5.
This allows PK2 to build and run on macOS again, as Homebrew has updated Lua to 5.5.

Updates sol2 to include upstream changes from:
https://github.com/ThePhD/sol2/pull/1723

Pinned to commit from the PR until it is merged upstream.